### PR TITLE
Fix fpinit_ASL error and use bounds on singletons

### DIFF
--- a/haskell-igraph.cabal
+++ b/haskell-igraph.cabal
@@ -276,7 +276,7 @@ library
       cbits/haskell_igraph.c
       igraph/src/abort_.c
       igraph/src/adjlist.c
-      igraph/src/arithchk.c
+      -- igraph/src/arithchk.c
       igraph/src/arpack.c
       igraph/src/array.c
       igraph/src/atlas.c

--- a/haskell-igraph.cabal
+++ b/haskell-igraph.cabal
@@ -828,7 +828,7 @@ library
     , containers
     , data-ordlist
     , primitive
-    , singletons >=2.7
+    , singletons == 2.7.*
   default-language: Haskell2010
 
 test-suite test


### PR DESCRIPTION
This makes the package buildable in a suitable Nix environment with cabal and stack.